### PR TITLE
Allow optional repo cloning on startup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,5 +5,10 @@ set -e
 iptables -A OUTPUT -d open-vsx.org -j REJECT || true
 iptables -A OUTPUT -d 65.9.95.66 -j REJECT || true
 
+# Si se proporciona un repositorio remoto, clónalo en el área de trabajo
+if [ -n "$GIT_REPO_URL" ]; then
+    gosu coder git clone "$GIT_REPO_URL" /home/coder/project || true
+fi
+
 # Ejecutar como usuario coder sin shell de login
 exec gosu coder dumb-init code-server --host 0.0.0.0 --port 8080 /home/coder/project

--- a/readme.md
+++ b/readme.md
@@ -40,8 +40,9 @@ Cuando se ejecuta el contenedor:
 
 1. Se bloquea el acceso al marketplace (`open-vsx.org`) y su IP mediante `iptables`.
 2. Se lanza Code-Server en el puerto `8080`.
-3. Se carga automáticamente el proyecto `HelloWorld` en el editor.
-4. El estudiante accede vía navegador, sin posibilidad de instalar nuevas extensiones ni salir del entorno.
+3. Si se define la variable de entorno `GIT_REPO_URL`, ese repositorio se clona en `/home/coder/project`.
+4. Se carga automáticamente el proyecto `HelloWorld` en el editor (o el clonado si existe).
+5. El estudiante accede vía navegador, sin posibilidad de instalar nuevas extensiones ni salir del entorno.
 
 ---
 
@@ -69,6 +70,7 @@ docker build -t vscode-java-safe .
 docker run -d \
   --name examen-java \
   -p 8080:8080 \
+  -e GIT_REPO_URL=https://tu.repo.git \
   vscode-java-safe
 ```
 


### PR DESCRIPTION
## Summary
- clone a repository on startup when `GIT_REPO_URL` is set
- document how to use `GIT_REPO_URL` when running the container

## Testing
- `bash -n entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_685592dba3fc8332869e420abf4c63f7